### PR TITLE
Feature/add columns and filtering

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -2,23 +2,56 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CampaignGetRequest;
 use App\Models\Brand;
 use App\Models\Campaign;
+use Illuminate\Database\Eloquent\Builder;
 
 class CampaignController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(CampaignGetRequest $request)
     {
-        return view('campaigns.index', [
-            'brands' => Brand::orderBy('name', 'asc')->get(),
-            'campaigns' => Campaign::orderBy('name', 'asc')->paginate(),
-            'start_date' => request('start_date', date('Y-m-d', strtotime('-7 days'))),
-            'end_date' => request('end_date', date('Y-m-d')),
-            'sort_by' => request('sort_by') ?? 'name',
-            'order_by' => request('order_by') ?? 'asc',
-        ]);
+        $sort_by = $request->get('sort_by') ?? 'name';
+        $order_by = $request->get('order_by') === 'desc' ? 'desc' : 'asc';
+        $start_date = $request->get('start_date', date('Y-m-d', strtotime('-7 days')));
+        $end_date = $request->get('end_date', date('Y-m-d'));
+        $brands = Brand::orderBy('name', 'asc')->get();
+
+        $query = Campaign::select('campaigns.*', 'brands.name as brand_name')
+            ->with('brand')
+            ->leftJoin('brands', 'campaigns.brand_id', '=', 'brands.id')
+            ->withCount([
+                'impressions' => function (Builder $query) use ($start_date, $end_date, $request) {
+                    if ($request->has('start_date') && $request->has('end_date')) {
+                        $query->whereBetween('occurred_at', [$start_date, $end_date]);
+                    }},
+                'interactions' => function (Builder $query) use ($start_date, $end_date, $request) {
+                    if ($request->has('start_date') && $request->has('end_date')) {
+                        $query->whereBetween('occurred_at', [$start_date, $end_date]);
+                    }},
+                'conversions' => function (Builder $query) use ($start_date, $end_date, $request) {
+                    if ($request->has('start_date') && $request->has('end_date')) {
+                        $query->whereBetween('occurred_at', [$start_date, $end_date]);
+                    }},
+            ]);
+
+        if ($request->has('brand') && $request->brand) {
+            $query->where('brand_id', $request->brand);
+        }
+
+        switch ($sort_by) {
+            case 'brand': $query->orderBy('brand_name', $order_by); break;
+            case 'conversions': $query->orderBy('conversions_count', $order_by); break;
+            case 'impressions': $query->orderBy('impressions_count', $order_by); break;
+            case 'interactions': $query->orderBy('interactions_count', $order_by); break;
+            default: $query->orderBy('campaigns.name', $order_by); break;
+        }
+
+        $campaigns = $query->paginate();
+
+        return view('campaigns.index', compact('campaigns', 'brands', 'sort_by', 'order_by', 'start_date', 'end_date'));
     }
 }

--- a/app/Http/Requests/CampaignGetRequest.php
+++ b/app/Http/Requests/CampaignGetRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CampaignGetRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'brand'      => 'exists:brands,id',
+            'start_date' => 'date',
+            'end_date'   => 'date',
+            'order_by'   => 'in:desc,asc',
+        ];
+    }
+}

--- a/database/migrations/2024_09_17_151216_add_occured_at_indexes.php
+++ b/database/migrations/2024_09_17_151216_add_occured_at_indexes.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('impressions', function (Blueprint $table) {
+            $table->index(['campaign_id', 'occurred_at']);
+            $table->index('campaign_id');
+        });
+
+        Schema::table('interactions', function (Blueprint $table) {
+            $table->index(['campaign_id', 'occurred_at']);
+            $table->index('campaign_id');
+        });
+
+        Schema::table('conversions', function (Blueprint $table) {
+            $table->index(['campaign_id', 'occurred_at']);
+            $table->index('campaign_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('impressions', function (Blueprint $table) {
+            $table->dropIndex('impressions_campaign_id_occurred_at_index');
+            $table->dropIndex('impressions_campaign_id_index');
+        });
+
+        Schema::table('interactions', function (Blueprint $table) {
+            $table->dropIndex('interactions_campaign_id_occurred_at_index');
+            $table->dropIndex('interactions_campaign_id_index');
+        });
+
+        Schema::table('conversions', function (Blueprint $table) {
+            $table->dropIndex('conversions_campaign_id_occurred_at_index');
+            $table->dropIndex('conversions_campaign_id_index');
+        });
+    }
+};

--- a/database/migrations/2024_09_17_160215_add_brands_name_index.php
+++ b/database/migrations/2024_09_17_160215_add_brands_name_index.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('brands', function (Blueprint $table) {
+            $table->index('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('brands', function (Blueprint $table) {
+            $table->dropIndex('brands_name_index');
+        });
+    }
+};

--- a/database/migrations/2024_09_17_164228_add_campaigns_name_index.php
+++ b/database/migrations/2024_09_17_164228_add_campaigns_name_index.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->index('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('campaigns', function (Blueprint $table) {
+            $table->dropIndex('campaigns_name_index');
+        });
+    }
+};

--- a/database/migrations/2024_09_17_225214_create_telescope_entries_table.php
+++ b/database/migrations/2024_09_17_225214_create_telescope_entries_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('telescope_entries', function (Blueprint $table) {
+            $table->bigIncrements('sequence');
+            $table->uuid('uuid');
+            $table->uuid('batch_id');
+            $table->string('family_hash')->nullable();
+            $table->boolean('should_display_on_index')->default(true);
+            $table->string('type', 20);
+            $table->longText('content');
+            $table->dateTime('created_at')->nullable();
+
+            $table->unique('uuid');
+            $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
+            $table->index(['type', 'should_display_on_index']);
+        });
+
+        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('entry_uuid');
+            $table->string('tag');
+
+            $table->primary(['entry_uuid', 'tag']);
+            $table->index('tag');
+
+            $table->foreign('entry_uuid')
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->onDelete('cascade');
+        });
+
+        $schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag')->primary();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('telescope_entries_tags');
+        $schema->dropIfExists('telescope_entries');
+        $schema->dropIfExists('telescope_monitoring');
+    }
+};

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -79,16 +79,16 @@
                     <td>{{ $campaign->name }}</td>
                     <td>{{ $campaign->brand->name }}</td>
                     <td>
-                        {{-- # of impressions in date range --}}
+                        {{ $campaign->impressions_count }}
                     </td>
                     <td>
-                        {{-- # of interactions in date range --}}
+                        {{ $campaign->interactions_count }}
                     </td>
                     <td>
-                        {{-- # of conversions in date range --}}
+                        {{ $campaign->conversions_count }}
                     </td>
                     <td>
-                        {{-- % conversion rate in date range --}}
+                        {{ round(($campaign->conversions_count / $campaign->impressions_count) * 100, 2) }}%
                     </td>
                 </tr>
                 @endforeach


### PR DESCRIPTION
## Other approaches explored/considered

### Left join subquery
Left join sub queries on campaign_id and occurred at then grouping by campaign_id proved way slower than the give solution, however would have allowed for sorting of the conversion_rate as that could have been included in the select statement, as opposed to being calculated in view as it is now.

### Caching
It was noted Caching through redis was available, however I felt due to the nature of impressions/interactions/conversions being added real time, it was probably not beneficial to add this data to cache, and would still have been a problem on initial page loading anyway. Plus the filtering on occurred_at would have made this approach a littler trickier.

### SQL View
I also considered an SQL view to collate counts for impressions/interactions/conversions, but again with the requirement for filtering through dates, it made this a little trickier.

## Could do better
I used laravel Debugbar to identify query issues and load times etc. The initial page loads quite quickly given the size of the dataset, and filtering of brand name and dates between works equaly as quick however the sorting of brand name, and the counts really slows down the query despite having relevant indexes, I tried other approaches as above, however they still weren't as optimal.
